### PR TITLE
PHP 8.4 compatible fputcsv/fgetcsv calls

### DIFF
--- a/application/datamapper/csv.php
+++ b/application/datamapper/csv.php
@@ -141,7 +141,7 @@ class DMZ_CSV {
 		}
 		$columns = NULL;
 		
-		while(($data = fgetcsv($fp, ',', '"', '')) !== FALSE)
+		while(($data = fgetcsv($fp, 0, ',', '"', '')) !== FALSE)
 		{
 			// get column names
 			if(is_null($columns))

--- a/application/datamapper/csv.php
+++ b/application/datamapper/csv.php
@@ -61,7 +61,7 @@ class DMZ_CSV {
 		if($include_header)
 		{
 			// Print out header line
-			$success = fputcsv($fp, $fields);
+			$success = fputcsv($fp, $fields, ',', '"', '');
 		}
 		
 		if($success)
@@ -75,7 +75,7 @@ class DMZ_CSV {
 					$result[] = $o->{$f};
 				}
 				// output CSV-formatted line
-				$success = fputcsv($fp, $result);
+				$success = fputcsv($fp, $result, ',', '"', '');
 				if(!$success)
 				{
 					// stop on first failure.
@@ -141,7 +141,7 @@ class DMZ_CSV {
 		}
 		$columns = NULL;
 		
-		while(($data = fgetcsv($fp)) !== FALSE)
+		while(($data = fgetcsv($fp, ',', '"', '')) !== FALSE)
 		{
 			// get column names
 			if(is_null($columns))


### PR DESCRIPTION
@saekort In PHP 8.4, `fputcsv` and `fgetcsv` require the `$escape` parameter to be specified. It is [recommended](https://php.watch/versions/8.4/csv-functions-escape-parameter) that it is empty.