### PR TITLE
Fix non-standard boolean cast name

### DIFF
--- a/application/libraries/datamapper.php
+++ b/application/libraries/datamapper.php
@@ -5962,7 +5962,7 @@ class DataMapper implements IteratorAggregate {
 	 */
 	protected function _boolean($field)
 	{
-		$this->{$field} = (boolean)$this->{$field};
+		$this->{$field} = (bool)$this->{$field};
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
PHP 8.5 [deprecates non-standard cast names](https://www.zend.com/blog/php-8-5-features#php-8-5-deprecations)